### PR TITLE
Adapt MfxVTK to the renamed branch of OpenMfx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 cmake-build*/
 tmp/
 docs/build/
+build*/

--- a/src/mfx_vtk_plugin/CMakeLists.txt
+++ b/src/mfx_vtk_plugin/CMakeLists.txt
@@ -37,10 +37,10 @@ set(SRC
         mfx_vtk_utils.h
         ${SRC_EFFECTS})
 
-# OpenMeshEffect dependency
+# OpenMfx dependency
 set(LIB
-  OpenMeshEffect::Core
-  OpenMeshEffect::Sdk
+  OpenMfx::Core
+  OpenMfx::Sdk
 )
 
 # Enable C++20 (required to use designated initializers)

--- a/src/mfx_vtk_plugin/CMakeLists.txt
+++ b/src/mfx_vtk_plugin/CMakeLists.txt
@@ -43,6 +43,12 @@ set(LIB
   OpenMeshEffect::Sdk
 )
 
+# Enable C++20 (required to use designated initializers)
+set(CMAKE_CXX_STANDARD 20)
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest")
+endif(MSVC)
+
 # VTK dependency, part 1
 find_package(VTK COMPONENTS
         vtkCommonCore

--- a/src/mfx_vtk_plugin/VtkEffect.cpp
+++ b/src/mfx_vtk_plugin/VtkEffect.cpp
@@ -97,9 +97,9 @@ OfxStatus VtkEffect::Cook(OfxMeshEffectHandle instance) {
 
     // prepare input, MFX -> VTK
     for (auto &vtk_input : vtk_inputs) {
-        if (vtk_input.definition->name == kOfxMeshMainInput) {
+        if (0 == strcmp(vtk_input.definition->name, kOfxMeshMainInput)) {
             vtk_main_input = &vtk_input;
-        } else if (vtk_input.definition->name == kOfxMeshMainOutput) {
+        } else if (0 == strcmp(vtk_input.definition->name, kOfxMeshMainOutput)) {
             vtk_main_output = &vtk_input;
         }
 

--- a/src/mfx_vtk_plugin/VtkEffectInputDef.cpp
+++ b/src/mfx_vtk_plugin/VtkEffectInputDef.cpp
@@ -28,8 +28,8 @@ VtkEffectInputDef & VtkEffectInputDef::RequestPointAttribute(const char* name, i
     return RequestAttribute(MfxAttributeAttachment::Point, name, componentCount, type, semantic, mandatory);
 }
 
-VtkEffectInputDef & VtkEffectInputDef::RequestVertexAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory) {
-    return RequestAttribute(MfxAttributeAttachment::Vertex, name, componentCount, type, semantic, mandatory);
+VtkEffectInputDef & VtkEffectInputDef::RequestCornerAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory) {
+    return RequestAttribute(MfxAttributeAttachment::Corner, name, componentCount, type, semantic, mandatory);
 }
 
 VtkEffectInputDef & VtkEffectInputDef::RequestFaceAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory) {

--- a/src/mfx_vtk_plugin/VtkEffectInputDef.h
+++ b/src/mfx_vtk_plugin/VtkEffectInputDef.h
@@ -26,7 +26,7 @@ struct VtkEffectInputDef {
     VtkEffectInputDef & Label(const char *label);
     VtkEffectInputDef & RequestAttribute(MfxAttributeAttachment attachment, const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory);
     VtkEffectInputDef & RequestPointAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory);
-    VtkEffectInputDef & RequestVertexAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory);
+    VtkEffectInputDef & RequestCornerAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory);
     VtkEffectInputDef & RequestFaceAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory);
     VtkEffectInputDef & RequestMeshAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory);
     VtkEffectInputDef & RequestGeometry(bool request);

--- a/src/mfx_vtk_plugin/effects/VtkDistanceAlongSurfaceEffect.cpp
+++ b/src/mfx_vtk_plugin/effects/VtkDistanceAlongSurfaceEffect.cpp
@@ -34,7 +34,7 @@ const char *VtkDistanceAlongSurfaceEffect::GetName() {
 
 OfxStatus
 VtkDistanceAlongSurfaceEffect::vtkDescribe(OfxParamSetHandle parameters, VtkEffectInputDef &input_mesh, VtkEffectInputDef &output_mesh) {
-    input_mesh.RequestVertexAttribute("color0", 3, MfxAttributeType::UByte, MfxAttributeSemantic::Color, true);
+    input_mesh.RequestCornerAttribute("color0", 3, MfxAttributeType::UByte, MfxAttributeSemantic::Color, true);
 
     // TODO declare this is a deformer
 

--- a/src/mfx_vtk_plugin/effects/VtkPokeEffect.cpp
+++ b/src/mfx_vtk_plugin/effects/VtkPokeEffect.cpp
@@ -45,12 +45,12 @@ const char *VtkPokeEffect::GetName() {
 }
 
 OfxStatus VtkPokeEffect::vtkDescribe(OfxParamSetHandle parameters, VtkEffectInputDef &input_mesh, VtkEffectInputDef &output_mesh) {
-    input_mesh.RequestVertexAttribute(ATTRIBUTE_COLOR, 3, MfxAttributeType::UByte, MfxAttributeSemantic::Color, false);
+    input_mesh.RequestCornerAttribute(ATTRIBUTE_COLOR, 3, MfxAttributeType::UByte, MfxAttributeSemantic::Color, false);
     input_mesh.RequestTransform(true);
 
     auto collider_mesh = vtkAddInput(INPUT_COLLIDER);
     collider_mesh->RequestTransform(true);
-    collider_mesh->RequestVertexAttribute(ATTRIBUTE_COLOR, 3, MfxAttributeType::UByte, MfxAttributeSemantic::Color, false);
+    collider_mesh->RequestCornerAttribute(ATTRIBUTE_COLOR, 3, MfxAttributeType::UByte, MfxAttributeSemantic::Color, false);
 
     AddParam(PARAM_MAX_DISTANCE, 0.0).Range(0.0, 1e6).Label("Maximum distance");
     AddParam(PARAM_FALLOFF_RADIUS, 0.01).Range(0.0, 1e6).Label("Falloff radius");

--- a/src/mfx_vtk_plugin/mfx_vtk_plugin_extra.cpp
+++ b/src/mfx_vtk_plugin/mfx_vtk_plugin_extra.cpp
@@ -578,22 +578,22 @@ public:
         output_mesh.FetchProperties(output_mesh_properties);
 
         MfxAttribute input_pointPos = input_mesh.GetPointAttribute(kOfxMeshAttribPointPosition);
-        MfxAttribute input_vertPoint = input_mesh.GetVertexAttribute(kOfxMeshAttribVertexPoint);
-        MfxAttribute input_faceLen = input_mesh.GetFaceAttribute(kOfxMeshAttribFaceCounts);
+        MfxAttribute input_vertPoint = input_mesh.GetCornerAttribute(kOfxMeshAttribCornerPoint);
+        MfxAttribute input_faceLen = input_mesh.GetFaceAttribute(kOfxMeshAttribFaceSize);
 
         MfxAttribute output_pointPos = output_mesh.GetPointAttribute(kOfxMeshAttribPointPosition);
-        MfxAttribute output_vertPoint = output_mesh.GetVertexAttribute(kOfxMeshAttribVertexPoint);
-        MfxAttribute output_faceLen = output_mesh.GetFaceAttribute(kOfxMeshAttribFaceCounts);
+        MfxAttribute output_vertPoint = output_mesh.GetCornerAttribute(kOfxMeshAttribCornerPoint);
+        MfxAttribute output_faceLen = output_mesh.GetFaceAttribute(kOfxMeshAttribFaceSize);
 
         output_pointPos.ForwardFrom(input_pointPos);
         output_vertPoint.ForwardFrom(input_vertPoint);
         output_faceLen.ForwardFrom(input_faceLen);
 
         output_mesh.Allocate(input_mesh_properties.pointCount,
-                             input_mesh_properties.vertexCount,
+                             input_mesh_properties.cornerCount,
                              input_mesh_properties.faceCount,
                              input_mesh_properties.noLooseEdge,
-                             input_mesh_properties.constantFaceCount);
+                             input_mesh_properties.constantFaceSize);
 
         output_mesh.Release();
         input_mesh.Release();


### PR DESCRIPTION
As mentioned in [OpenMeshEffect#12](https://github.com/eliemichel/OpenMeshEffect/issues/12), there is a few renaming points coming up:

 - Open Mesh Effect -> OpenMfx (I haven't changed all comments yet)
 - Vertex -> Corner
 - FaceCounts -> FaceSize

This updated version of MfxVTK is compatible with the `rename` branch of OpenMeshEffectForBlender and OpenMeshEffect repos.